### PR TITLE
Addition qemu-user binfmt targets

### DIFF
--- a/qemu.nix
+++ b/qemu.nix
@@ -3,21 +3,31 @@
 with lib;
 let
   cfg = config.qemu-user;
-  arm = {
-    interpreter = "${pkgs.qemu-user-arm}/bin/qemu-arm";
-    magicOrExtension = ''\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00'';
+  archMagics = {
+    x86 = "\x03\x00";
+    arm = "\x28\x00";
+    x86_64 = "\x3e\x00"
+    aarch64 = "\xb7\x00";
+    riscv = "\xf3\x00" # Same ID for 32 and 64 bit
+  };
+  makeBinfmt = interpreter: bit64: archMagic: {
+    inherit interpreter;
+    magicOrExtension = ''\x7fELF${if bit64 then "\x02" else "\x01"}\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\${archMagic}'';
     mask = ''\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\x00\xff\xfe\xff\xff\xff'';
   };
-  aarch64 = {
-    interpreter = "${pkgs.qemu-user-arm64}/bin/qemu-aarch64";
-    magicOrExtension = ''\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00'';
-    mask = ''\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\x00\xff\xfe\xff\xff\xff'';
-  };
+  arm = makeBinfmt "${pkgs.qemu-user-arm}/bin/qemu-arm" false archMagics.arm;
+  x86 = makeBinfmt "${pkgs.qemu-user-x86}/bin/qemu-x86_64" true archMagics.x86_64;
+  aarch64 = makeBinfmt "${pkgs.qemu-user-arm64}/bin/qemu-aarch64" true archMagics.aarch64;
+  riscv32 = makeBinfmt "${pkgs.qemu-user-riscv32}/bin/qemu-riscv32" false archMagics.riscv;
+  riscv32 = makeBinfmt "${pkgs.qemu-user-riscv64}/bin/qemu-riscv64" true archMagics.riscv;
 in {
   options = {
     qemu-user = {
       arm = mkEnableOption "enable 32bit arm emulation";
+      x86 = mkEnableOption "enable 32 and 64 bit x86 emulation";
       aarch64 = mkEnableOption "enable 64bit arm emulation";
+      riscv32 = mkEnableOption "enable 32bit risc-v emulation";
+      riscv64 = mkEnableOption "enable 64bit risc-v emulation";
     };
     nix.supportedPlatforms = mkOption {
       type = types.listOf types.str;
@@ -31,12 +41,25 @@ in {
     };
     boot.binfmtMiscRegistrations =
       optionalAttrs cfg.arm { inherit arm; } //
-      optionalAttrs cfg.aarch64 { inherit aarch64; };
-    nix.supportedPlatforms = (optionals cfg.arm [ "armv6l-linux" "armv7l-linux" ]) ++ (optional cfg.aarch64 "aarch64-linux");
+      optionalAttrs cfg.x86 { inherit x86; } //
+      optionalAttrs cfg.aarch64 { inherit aarch64; } //
+      optionalAttrs cfg.riscv32 { inherit riscv32; } //
+      optionalAttrs cfg.riscv64 { inherit riscv64; };
+    nix.supportedPlatforms =
+      (optionals cfg.arm [ "armv6l-linux" "armv7l-linux" ]) ++
+      (optionals cfg.x86 [ "x86-linux" "x86_64-linux" ]) ++
+      (optional cfg.aarch64 "aarch64-linux") ++
+      (optional cfg.riscv32 "riscv32-linux") ++
+      (optional cfg.riscv64 "riscv64-linux");
     nix.package = pkgs.patchedNix;
     nix.extraOptions = ''
       build-extra-platforms = ${toString config.nix.supportedPlatforms}
     '';
-    nix.sandboxPaths = [ "/run/binfmt" ] ++ (optional cfg.arm "${pkgs.qemu-user-arm}") ++ (optional cfg.aarch64 "${pkgs.qemu-user-arm64}");
+    nix.sandboxPaths = [ "/run/binfmt" ] ++ 
+      (optional cfg.arm "${pkgs.qemu-user-arm}") ++
+      (optional cfg.x86 "${pkgs.qemu-user-x86}") ++
+      (optional cfg.aarch64 "${pkgs.qemu-user-arm64}") ++
+      (optional cfg.riscv32 "${pkgs.qemu-user-riscv32}") ++
+      (optional cfg.riscv64 "${pkgs.qemu-user-riscv64}");
   };
 }

--- a/qemu.nix
+++ b/qemu.nix
@@ -6,9 +6,9 @@ let
   archMagics = {
     x86 = "\x03\x00";
     arm = "\x28\x00";
-    x86_64 = "\x3e\x00"
+    x86_64 = "\x3e\x00";
     aarch64 = "\xb7\x00";
-    riscv = "\xf3\x00" # Same ID for 32 and 64 bit
+    riscv = "\xf3\x00"; # Same ID for 32 and 64 bit
   };
   makeBinfmt = interpreter: bit64: archMagic: {
     inherit interpreter;

--- a/qemu.nix
+++ b/qemu.nix
@@ -41,7 +41,7 @@ in {
     };
     boot.binfmtMiscRegistrations =
       optionalAttrs cfg.arm { inherit arm; } //
-      optionalAttrs cfg.x86 { inherit x86; } //
+      optionalAttrs cfg.x86 { inherit x86_64; } //
       optionalAttrs cfg.aarch64 { inherit aarch64; } //
       optionalAttrs cfg.riscv32 { inherit riscv32; } //
       optionalAttrs cfg.riscv64 { inherit riscv64; };

--- a/qemu.nix
+++ b/qemu.nix
@@ -16,7 +16,7 @@ let
     mask = ''\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\x00\xff\xfe\xff\xff\xff'';
   };
   arm = makeBinfmt "${pkgs.qemu-user-arm}/bin/qemu-arm" false archMagics.arm;
-  x86 = makeBinfmt "${pkgs.qemu-user-x86}/bin/qemu-x86_64" true archMagics.x86_64;
+  x86_64 = makeBinfmt "${pkgs.qemu-user-x86}/bin/qemu-x86_64" true archMagics.x86_64;
   aarch64 = makeBinfmt "${pkgs.qemu-user-arm64}/bin/qemu-aarch64" true archMagics.aarch64;
   riscv32 = makeBinfmt "${pkgs.qemu-user-riscv32}/bin/qemu-riscv32" false archMagics.riscv;
   riscv32 = makeBinfmt "${pkgs.qemu-user-riscv64}/bin/qemu-riscv64" true archMagics.riscv;
@@ -24,7 +24,7 @@ in {
   options = {
     qemu-user = {
       arm = mkEnableOption "enable 32bit arm emulation";
-      x86 = mkEnableOption "enable 32 and 64 bit x86 emulation";
+      x86 = mkEnableOption "enable 64bit x86 emulation";
       aarch64 = mkEnableOption "enable 64bit arm emulation";
       riscv32 = mkEnableOption "enable 32bit risc-v emulation";
       riscv64 = mkEnableOption "enable 64bit risc-v emulation";
@@ -47,7 +47,7 @@ in {
       optionalAttrs cfg.riscv64 { inherit riscv64; };
     nix.supportedPlatforms =
       (optionals cfg.arm [ "armv6l-linux" "armv7l-linux" ]) ++
-      (optionals cfg.x86 [ "x86-linux" "x86_64-linux" ]) ++
+      (optional cfg.x86 "x86_64-linux") ++
       (optional cfg.aarch64 "aarch64-linux") ++
       (optional cfg.riscv32 "riscv32-linux") ++
       (optional cfg.riscv64 "riscv64-linux");


### PR DESCRIPTION
Adds additional options to qemu-user to build binfmt configurations for all currently provided qemu-user builds.

I apologise for the many small commits. I was doing this through the github interface.